### PR TITLE
Update INPUT_SCHEMA.json

### DIFF
--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -164,7 +164,7 @@
             "type": "string",
             "nullable": true,
             "description": "Function that takes a JQuery handle ($) as argument and returns data that will be merged with the default output",
-            "prefill": "($) => { return {} }",
+            "prefill": "() => { return {} }",
             "editor": "javascript"
         }
     },


### PR DESCRIPTION
remove local variable $

otherwise using `$()` will error with `Error: Evaluation failed: TypeError: $ is not a function` since the $ isn't being passed as a parameter to the `fn` in https://github.com/dtrungtin/actor-booking-scraper/blob/master/src/main.js#L193