### PR TITLE
Fix/scraped details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 
 apify_storage
+/package-lock.json

--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -346,7 +346,7 @@
         "minMaxPrice": {
             "title": "Price range",
             "type": "string",
-            "description": "Minimum-maximum price range in '100-150' or '200+' format",
+            "description": "Minimum-maximum price range in 100-150 or 200+ format",
             "editor": "textfield",
             "prefill": "100-150"
         },

--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -346,17 +346,9 @@
         "minMaxPrice": {
             "title": "Price range",
             "type": "string",
-            "description": "Minimum-maximum price range",
-            "default": "none",
-            "enum": ["none", "0-50", "50-100", "100-150", "150-200", "200+"],
-            "enumTitles": [
-                "none",
-                "0 - € 50",
-                "€ 50 - € 100",
-                "€ 100 - € 150",
-                "€ 150 - € 200",
-                "€ 200 +"
-            ]
+            "description": "Minimum-maximum price range in '100-150' or '200+' format",
+            "editor": "textfield",
+            "prefill": "100-150"
         },
         "proxyConfig": {
             "title": "Proxy Configuration",

--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -346,7 +346,7 @@
         "minMaxPrice": {
             "title": "Price range",
             "type": "string",
-            "description": "Minimum-maximum price range in 100-150 or 200+ format",
+            "description": "Minimum-maximum price range in min-max or min+ format (such as 100-150, 200-225, 300+, ...)",
             "editor": "textfield",
             "prefill": "100-150"
         },

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Input is a JSON object with the following properties:
 * `language` preferred language code to be set on the site.
 * `propertyType` type of property to search, it will use filters, so cannot be combined with `useFilters`.
 Must be one of the following:
-```javascript
+```json
 [
     "none",
     "Hotels",
@@ -78,7 +78,7 @@ Must be one of the following:
 ```
 * `minMaxPrice` min-max price range, it will use filters, so cannot be combined with `useFilters`.
 Must be one of the following:
-```javascript
+```json
 [
     "none",
     "0-50",
@@ -89,7 +89,7 @@ Must be one of the following:
 ]
 ```
 * `proxyConfig` defines Apify proxy configuration and default group is SHADER, it should respect this format:
-```javascript
+```json
 "proxyConfig": {
     "useApifyProxy": true,
     "apifyProxyGroups": [
@@ -98,7 +98,7 @@ Must be one of the following:
 }
 ```
 * `sortBy` sets a hotel attribute by which the results will be ordered, must be one of the following.
-```javascript
+```json
 [
     "upsort_bh",                 // Show homes first
     "price",                     // Price (lowest first)
@@ -123,7 +123,7 @@ will depend on the `simple` attribute. If it's `true`, the page will be scraped,
 detail pages will be added to the queue and scraped afterwards.
 The `startUrls` attribute should contain an array of URLs as follows:
 
-```javascript
+```json
 {
     "startUrls": [
         "https://www.booking.com/hotel/fr/ariane-montparnasse.en-gb.html",
@@ -141,25 +141,39 @@ The `startUrls` attribute should contain an array of URLs as follows:
 
 In case of using the `simple` INPUT attribute, an example output for a single hotel can look like this:
 
-```javascript
+```json
 {
   "url": "https://www.booking.com/hotel/cz/elia-ky-kra-snohorska-c-apartments-prague.en-gb.html",
   "name": "Centrum Apartments Old Town",
+  "address": "Prague 01, Prague",
   "rating": 10,
   "reviews": 7,
   "stars": 4,
   "price": 86,
   "currency": "€",
   "roomType": "Deluxe Three-Bedroom Apartment with Terrace",
-  "persons": 4,
+  "persons": 4
+}
+```
+
+If `checkIn` and `checkOut` INPUT attributes are not provided, simple output is further reduced as `price`,
+`currency`, `roomType` and `persons` can't be scraped from the listing page. The output follows this format:
+
+```json
+{
+  "url": "https://www.booking.com/hotel/cz/elia-ky-kra-snohorska-c-apartments-prague.en-gb.html",
+  "name": "Centrum Apartments Old Town",
   "address": "Prague 01, Prague",
+  "rating": 10,
+  "reviews": 7,
+  "stars": 4
 }
 ```
 
 Otherwise the output will be much more comprehensive, especially the `rooms` array, which will however
 contain data only if the `checkIn` and `checkOut` INPUT attributes are set.
 
-```javascript
+```json
 {
   "url": "https://www.booking.com/hotel/cz/elia-ky-kra-snohorska-c-apartments-prague.en-gb.html",
   "name": "Centrum Apartments Old Town",

--- a/README.md
+++ b/README.md
@@ -76,18 +76,12 @@ Must be one of the following:
     "Luxury tents"
 ]
 ```
-* `minMaxPrice` min-max price range, it will use filters, so cannot be combined with `useFilters`.
-Must be one of the following:
-```json
-[
-    "none",
-    "0-50",
-    "50-100",
-    "100-150",
-    "150-200",
-    "200+"
-]
-```
+* `minMaxPrice` min-max price range, it will filter the results, so it cannot be combined with `useFilters`.
+You can use one of the following formats (or exclude the attribute from INPUT completely):
+`none`, `100-150`, `200+`. Note that the actor sets custom price filter so you can provide arbitrary price range
+and you don't need to limit yourself on the given ranges from booking.com website. You can even specify more specific
+price range than booking.com offers in price filters (e.g. Booking has price category 500+ but you can set values
+such as 520-550, 650-680, 700+, ...). The values apply to the currency provided as another INPUT attribute.
 * `proxyConfig` defines Apify proxy configuration and default group is SHADER, it should respect this format:
 ```json
 "proxyConfig": {
@@ -98,7 +92,7 @@ Must be one of the following:
 }
 ```
 * `sortBy` sets a hotel attribute by which the results will be ordered, must be one of the following.
-```json
+```javascript
 [
     "upsort_bh",                 // Show homes first
     "price",                     // Price (lowest first)
@@ -123,7 +117,7 @@ will depend on the `simple` attribute. If it's `true`, the page will be scraped,
 detail pages will be added to the queue and scraped afterwards.
 The `startUrls` attribute should contain an array of URLs as follows:
 
-```json
+```javascript
 {
     "startUrls": [
         "https://www.booking.com/hotel/fr/ariane-montparnasse.en-gb.html",
@@ -157,7 +151,7 @@ In case of using the `simple` INPUT attribute, an example output for a single ho
 ```
 
 If `checkIn` and `checkOut` INPUT attributes are not provided, simple output is further reduced as `price`,
-`currency`, `roomType` and `persons` can't be scraped from the listing page. The output follows this format:
+`currency`, `roomType` and `persons` cannot be scraped from the listing page. The output follows this format:
 
 ```json
 {
@@ -200,8 +194,7 @@ contain data only if the `checkIn` and `checkOut` INPUT attributes are set.
   "images": [
     "https://cf.bstatic.com/xdata/images/hotel/max1024x768/303439628.jpg?k=7f001a9cbf85160050efc5437e3ba5adac7b23db47a5a2dbb8c10640b4e7b042&o=&hp=1",
     "https://cf.bstatic.com/xdata/images/hotel/max1024x768/202101343.jpg?k=afd7a3e75f1f758b4137f9605645e7e23d42eadc9e18137d3c435d628b11c46d&o=&hp=1",
-    "https://cf.bstatic.com/xdata/images/hotel/max1024x768/183313960.jpg?k=fb7411388bf11432cf7613ab3318d5b5f1d767741f18095d034d4f430252a841&o=&hp=1",
-    ...
+    "https://cf.bstatic.com/xdata/images/hotel/max1024x768/183313960.jpg?k=fb7411388bf11432cf7613ab3318d5b5f1d767741f18095d034d4f430252a841&o=&hp=1"
   ],
   "rooms": [
     {
@@ -217,14 +210,12 @@ contain data only if the `checkIn` and `checkOut` INPUT attributes are set.
         "Terrace",
         "Flat-screen TV",
         "Air conditioning",
-        "Private bathroom",
-        ...
+        "Private bathroom"
       ],
       "conditions": [
         "Non-refundable"
       ]
-    },
-    ...
+    }
   ]
 }
 ```

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,7 +1,7 @@
 module.exports = {
-    // TODO: Check if this is good
     USER_AGENT: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
     MAX_OFFSET: 5000, // to ensure that scraper does not run infinitely
+    DATE_FORMAT: 'YYYY-MM-DD',
     DEFAULT_MIN_SCORE: 84,
     PROPERTY_TYPE_IDS: {
         Hotels: 204,

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,6 +1,7 @@
 module.exports = {
     USER_AGENT: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
     MAX_OFFSET: 5000, // to ensure that scraper does not run infinitely
+    MAX_RESULTS_LIMIT: 1000,
     DATE_FORMAT: 'YYYY-MM-DD',
     DEFAULT_MIN_SCORE: 84,
     PROPERTY_TYPE_IDS: {

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,7 +1,21 @@
 module.exports = {
     // TODO: Check if this is good
     USER_AGENT: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36',
-    PRICE_LABELS: ['0-50', '50-100', '100-150', '150-200', '200+'],
     MAX_OFFSET: 5000, // to ensure that scraper does not run infinitely
     DEFAULT_MIN_SCORE: 84,
+    PROPERTY_TYPE_IDS: {
+        Hotels: 204,
+        Apartments: 201,
+        Hostels: 203,
+        Homestays: 222,
+        Boats: 215,
+        Villas: 213,
+        Motels: 205,
+        Campsites: 214, // same as Campgrounds
+        'Guest houses': 216,
+        'Bed and breakfasts': 208,
+        'Holiday homes': 220, // same as Vacation homes
+        'Holiday parks': 212,
+        'Luxury tents': 224,
+    },
 };

--- a/src/extraction.js
+++ b/src/extraction.js
@@ -115,9 +115,9 @@ const extractSimpleRoomsInfo = () => {
         return multiplierValue ? multiplierValue * roomPersons : roomPersons;
     });
 
-    for (let index = 0; index < rooms.length; index++) {
-        const room = rooms[index];
-        room.persons = persons[index];
+    for (let i = 0; i < rooms.length; i++) {
+        const room = rooms[i];
+        room.persons = persons[i];
     }
 
     return rooms;
@@ -222,13 +222,13 @@ module.exports.listPageFunction = (input) => new Promise((resolve) => {
     let finished = 0;
 
     // Iterate all items
-    items.each(function (index, sr) {
+    items.each(function (_i, sr) {
         const jThis = $(this);
-        const n1 = jThis.find('.score_from_number_of_reviews').text().replace(/(\s|\.|,)+/g, '').match(/\d+/);
-        const n2 = jThis.find('.review-score-widget__subtext').text().replace(/(\s|\.|,)+/g, '').match(/\d+/);
-        const n3 = jThis.find('.bui-review-score__text').text().replace(/(\s|\.|,)+/g, '').match(/\d+/);
-        const n4 = jThis.find('[data-testid="review-score"] > div:nth-child(2) > div:nth-child(2)').text();
-        const nReviews = n1 || n2 || n3 || n4;
+        const reviewsFirstOpt = jThis.find('.score_from_number_of_reviews').text().replace(/(\s|\.|,)+/g, '').match(/\d+/);
+        const reviewsSecondOpt = jThis.find('.review-score-widget__subtext').text().replace(/(\s|\.|,)+/g, '').match(/\d+/);
+        const reviewsThirdOpt = jThis.find('.bui-review-score__text').text().replace(/(\s|\.|,)+/g, '').match(/\d+/);
+        const reviewsFourthOpt = jThis.find('[data-testid="review-score"] > div:nth-child(2) > div:nth-child(2)').text();
+        const reviewsCountMatches = reviewsFirstOpt || reviewsSecondOpt || reviewsThirdOpt || reviewsFourthOpt;
 
         ++started;
         sr.scrollIntoView();
@@ -242,21 +242,21 @@ module.exports.listPageFunction = (input) => new Promise((resolve) => {
             /* eslint-disable */
             const origin = window.location.origin;
             /* eslint-enable */
-            const rl1 = jThis.find('.room_link span').eq(0).contents();
+            const roomLinkFirstOpt = jThis.find('.room_link span').eq(0).contents();
             // eslint-disable-next-line max-len
-            const rl2 = jThis.find('.room_link strong').length > 0 ? jThis.find('.room_link strong') : jThis.find('[data-testid="recommended-units"] [role=link]');
+            const roomLinkSecondOpt = jThis.find('.room_link strong').length > 0 ? jThis.find('.room_link strong') : jThis.find('[data-testid="recommended-units"] [role=link]');
 
             // if more prices are extracted, first one is the original, second one is current discount
             const prices = getPrices();
-            const prtxt = prices.length > 1 ? prices.eq(1).text() : prices.eq(0).text()
+            const pricesText = prices.length > 1 ? prices.eq(1).text() : prices.eq(0).text()
                 .replace(/,|\s/g, '');
-            const pr = prtxt.match(/[\d.]+/);
-            const pc = prtxt.match(/[^\d.]+/);
+            const priceValue = pricesText.match(/[\d.]+/);
+            const priceCurrency = pricesText.match(/[^\d.]+/);
 
             const taxAndFeeText = jThis.find('.prd-taxes-and-fees-under-price').eq(0).text().trim();
             const taxAndFee = taxAndFeeText.match(/\d+/);
 
-            const rat = $(sr).attr('data-score') || jThis.find('[data-testid="review-score"] > div:first-child').text();
+            const reviewScore = $(sr).attr('data-score') || jThis.find('[data-testid="review-score"] > div:first-child').text();
 
             const starAttr = jThis.find('.bui-rating').attr('aria-label');
             const stars = starAttr ? starAttr.match(/\d/) : [jThis.find('[data-testid="rating-stars"] span').length];
@@ -271,11 +271,11 @@ module.exports.listPageFunction = (input) => new Promise((resolve) => {
             let url = hotelLink ? hotelLink.replace(/\n/g, '') : jThis.find('a').attr('href').replace(/\n/g, '');
             url = url.includes(origin) ? url : `${origin}${url}`;
 
-            const textRoomType = rl2.length > 0 ? rl2.text().trim() : rl1.eq(0).text().trim();
+            const textRoomType = roomLinkSecondOpt.length > 0 ? roomLinkSecondOpt.text().trim() : roomLinkFirstOpt.eq(0).text().trim();
 
             const optionalProperties = {
-                price: pr ? (parseFloat(pr[0]) + (taxAndFee ? parseFloat(taxAndFee[0]) : 0)) : null,
-                currency: pc ? pc[0].trim() : null,
+                price: priceValue ? (parseFloat(priceValue[0]) + (taxAndFee ? parseFloat(taxAndFee[0]) : 0)) : null,
+                currency: priceCurrency ? priceCurrency[0].trim() : null,
                 roomType: textRoomType || null,
                 persons: nightsPersonsSplits.length > 1 ? parseInt(nightsPersonsSplits[1], 10) : null,
             };
@@ -288,8 +288,8 @@ module.exports.listPageFunction = (input) => new Promise((resolve) => {
                 url: url.split('?')[0],
                 name: $(sr).find('.sr-hotel__name, [data-testid="title"]').text().trim(),
                 address: jThis.find('[data-testid="address"]').text(),
-                rating: rat ? parseFloat(rat.replace(',', '.')) : null,
-                reviews: nReviews ? parseInt(nReviews[0], 10) : null,
+                rating: reviewScore ? parseFloat(reviewScore.replace(',', '.')) : null,
+                reviews: reviewsCountMatches ? parseInt(reviewsCountMatches[0], 10) : null,
                 stars: starsCount !== 0 ? starsCount : null,
                 ...extraProperties,
                 image,

--- a/src/extraction.js
+++ b/src/extraction.js
@@ -259,6 +259,8 @@ module.exports.listPageFunction = (input) => new Promise((resolve) => {
             const hotelLink = jThis.find('.hotel_name_link').attr('href');
             let url = hotelLink ? hotelLink.replace(/\n/g, '') : jThis.find('a').attr('href').replace(/\n/g, '');
             url = url.includes(origin) ? url : `${origin}${url}`;
+            const textRoomType = rl2.length > 0 ? rl2.text().trim() : rl1.eq(0).text().trim();
+
             const item = {
                 url: url.split('?')[0],
                 name: $(sr).find('.sr-hotel__name, [data-testid=title]').text().trim(),
@@ -267,7 +269,7 @@ module.exports.listPageFunction = (input) => new Promise((resolve) => {
                 stars: starsCount !== 0 ? starsCount : null,
                 price: pr ? (parseFloat(pr[0]) + (taxAndFee ? parseFloat(taxAndFee[0]) : 0)) : null,
                 currency: pc ? pc[0].trim() : null,
-                roomType: rl2.length > 0 ? rl2.text().trim() : rl1.eq(0).text().trim(),
+                roomType: textRoomType || null,
                 address: jThis.find('[data-testid=address]').text(),
                 image,
             };

--- a/src/extraction.js
+++ b/src/extraction.js
@@ -144,6 +144,7 @@ module.exports.extractDetail = async (page, ld, input, userData) => {
     const description = await page.$('#property_description_content');
     const descriptionText = description ? await getAttribute(description, 'textContent') : null;
     const hType = await page.$('.hp__hotel-type-badge');
+    const pType = await page.$('.bh-property-type');
     const bFast = await page.$('.ph-item-copy-breakfast-option');
     const starTitle = await page.evaluate(() => {
         const el = document.querySelector('.bui-rating');
@@ -163,11 +164,14 @@ module.exports.extractDetail = async (page, ld, input, userData) => {
     const price = rooms.length > 0 ? rooms[0].price : null;
     const images = await page.evaluate(() => { return window.booking.env.hotelPhotos.map((photo) => photo.large_url); });
 
+    const homeType = hType ? await getAttribute(hType, 'textContent') : null;
+    const propertyType = pType ? await getAttribute(pType, 'textContent') : null;
+
     return {
         order: userData.order,
         url: addUrlParameters(page.url().split('?')[0], input),
         name: nameText ? nameText[nameText.length - 1].trim() : null,
-        type: hType ? await getAttribute(hType, 'textContent') : null,
+        type: homeType || propertyType,
         description: descriptionText || null,
         stars,
         price,

--- a/src/handle-page-function.js
+++ b/src/handle-page-function.js
@@ -8,144 +8,211 @@ const {
 
 const { log } = Apify.utils;
 
-module.exports = async ({ page, request, session, requestQueue, startUrls, input,
-    extendOutputFunction, sortBy, maxPages, state }) => {
-    const { url, userData: { label, filtered } } = request;
+module.exports = async ({ page, request, session, extendOutputFunction, requestQueue, input,
+    sortBy, state }) => {
+    const { url, userData } = request;
+    const { label } = userData;
 
     log.info(`open url(${label}): ${url}`);
 
     if (label === 'detail') { // Extract data from the hotel detail page
-        // wait for necessary elements
-        try { await page.waitForSelector('.bicon-occupancy'); } catch (e) { log.info('occupancy info not found'); }
-
-        const ldElem = await page.$('script[type="application/ld+json"]');
-        const ld = JSON.parse(await getAttribute(ldElem, 'textContent'));
-        await Apify.utils.puppeteer.injectJQuery(page);
-
-        // Check if the page was opened through working proxy.
-        const pageUrl = page.url();
-        if (!startUrls && pageUrl.indexOf('label') < 0) {
-            session.retire();
-            throw new Error(`Page was not opened correctly`);
-        }
-
-        // Exit if core data is not present or the rating is too low.
-        if (!ld || (input.minScore && ld.aggregateRating && ld.aggregateRating.ratingValue < input.minScore)) {
-            return;
-        }
-
-        // Extract the data.
-        log.info('extracting detail...');
-        const detail = await extractDetail(page, ld, input, request.userData);
-        log.info('detail extracted');
-        let userResult = {};
-
-        if (extendOutputFunction) {
-            userResult = await page.evaluate(async (functionStr) => {
-                // eslint-disable-next-line no-eval
-                const f = eval(functionStr);
-                return f(window.jQuery);
-            }, input.extendOutputFunction);
-
-            if (!isObject(userResult)) {
-                log.info('extendOutputFunction has to return an object!!!');
-                process.exit(1);
-            }
-        }
-
-        await Apify.pushData({ ...detail, ...userResult });
+        await handleDetailPage(page, input, userData, session, extendOutputFunction);
     } else {
-        const countSelector = '.sorth1, .sr_header h1, .sr_header h2, [data-capla-component*="HeaderDesktop"] h1';
-        await page.waitForSelector(countSelector, { timeout: 60000 });
-        const heading = await page.$(countSelector);
-        const headingText = heading ? (await getAttribute(heading, 'textContent')).trim() : 'No heading found.';
-        log.info(headingText);
+        await handleStartPage(page, input, request, session, requestQueue, sortBy, state);
+    }
+};
 
-        // Handle hotel list page.
-        const settingFilters = input.useFilters;
-        const enqueuingReady = filtered || !(settingFilters);
+const handleDetailPage = async (page, input, userData, session, extendOutputFunction) => {
+    const { startUrls, minScore } = input;
 
-        // Check if the page was opened through working proxy.
-        const pageUrl = page.url();
-        if (!startUrls && pageUrl.indexOf(sortBy) < 0) {
-            session.retire();
-            throw new Error(`Page was not opened correctly`);
-        }
+    await waitForDetailPageToLoad(page);
 
-        // If it's aprropriate, enqueue all pagination pages
-        if (enqueuingReady && (!maxPages || maxPages > 1 || input.useFilters || input.minMaxPrice !== 'none' || input.propertyType !== 'none')) {
-            if (input.useFilters) {
-                await enqueueAllPages(page, requestQueue, input, 0);
-            } else if (!maxPages || maxPages > 1) {
-                await enqueueAllPages(page, requestQueue, input, maxPages);
-            }
-        }
+    const ldElem = await page.$('script[type="application/ld+json"]');
+    const ld = JSON.parse(await getAttribute(ldElem, 'textContent'));
+    await Apify.utils.puppeteer.injectJQuery(page);
 
-        // If filtering is enabled, enqueue necessary pages.
-        if (settingFilters) {
-            log.info('enqueuing filtered pages...');
+    // Check if the page was opened through working proxy.
+    validateProxy(page, session, startUrls, 'label');
 
-            const attributeToExtract = 'value';
-            const filterCheckboxSelector = `[type="checkbox"][${attributeToExtract}]:not([checked]):not(.bui-checkbox__input)`;
-            await enqueueLinks(page, filterCheckboxSelector, attributeToExtract, 'start', request.url, requestQueue);
-        }
+    // Exit if core data is not present or the rating is too low.
+    if (!ld || (minScore && ld.aggregateRating && ld.aggregateRating.ratingValue < minScore)) {
+        return;
+    }
 
-        // eslint-disable-next-line max-len
-        const items = await page.$$('.sr_property_block.sr_item:not(.soldout_property), [data-capla-component*="PropertiesListDesktop"] [data-testid="property-card"]');
-        if (items.length === 0) {
-            log.info('Found no result. Skipping..');
-            return;
-        }
+    // Extract the data.
+    log.info('extracting detail...');
+    const detail = await extractDetail(page, ld, input, userData);
+    log.info('detail extracted');
 
-        if (enqueuingReady && input.simple) { // If simple output is enough, extract the data.
-            log.info('extracting data...');
-            await Apify.utils.puppeteer.injectJQuery(page);
-            const result = await page.evaluate(listPageFunction, input);
+    const userResult = await getUserResult(page, extendOutputFunction, input.extendOutputFunction);
 
-            if (result.length > 0) {
-                const toBeAdded = [];
-                for (const item of result) {
-                    item.url = addUrlParameters(item.url, input);
-                    if (!state.crawled[item.name]) {
-                        toBeAdded.push(item);
-                        state.crawled[item.name] = true;
-                    }
-                }
+    await Apify.pushData({ ...detail, ...userResult });
+};
 
-                log.info(`Found ${toBeAdded.length} new results out of ${result.length} results.`);
+const getUserResult = async (page, extendOutputFunction, inputExtendOutputFunction) => {
+    let userResult = {};
 
-                if (toBeAdded.length > 0) {
-                    await Apify.pushData(toBeAdded);
-                }
-            }
-        } else if (enqueuingReady) { // If not, enqueue the detail pages to be extracted.
-            log.info('enqueuing detail pages...');
-            const urlMod = fixUrl('&', input);
-            const keyMod = async (link) => (await getAttribute(link, 'textContent')).trim().replace(/\n/g, '');
-            const prItem = await page.$('.bui-pagination__info');
-            const pageRange = (await getAttribute(prItem, 'textContent')).match(/\d+/g);
-            const firstItem = parseInt(pageRange && pageRange[0] ? pageRange[0] : '1', 10);
-            // eslint-disable-next-line max-len
-            const links = await page.$$('.sr_property_block.sr_item:not(.soldout_property) .hotel_name_link, [data-capla-component*="PropertiesListDesktop"] [data-testid="property-card"] a[data-testid="title-link"]');
+    if (extendOutputFunction) {
+        userResult = await page.evaluate(async (functionStr) => {
+            // eslint-disable-next-line no-eval
+            const f = eval(functionStr);
+            return f(window.jQuery);
+        }, inputExtendOutputFunction);
 
-            for (let iLink = 0; iLink < links.length; iLink++) {
-                const link = links[iLink];
-                const href = await getAttribute(link, 'href');
-
-                if (href) {
-                    const uniqueKeyCal = keyMod ? (await keyMod(link)) : href;
-                    const urlModCal = urlMod ? urlMod(href) : href;
-
-                    await requestQueue.addRequest({
-                        userData: {
-                            label: 'detail',
-                            order: iLink + firstItem,
-                        },
-                        url: urlModCal,
-                        uniqueKey: uniqueKeyCal,
-                    }, { forefront: true });
-                }
-            }
+        if (!isObject(userResult)) {
+            log.info('extendOutputFunction has to return an object!!!');
+            process.exit(1);
         }
     }
+
+    return userResult;
+};
+
+const handleStartPage = async (page, input, request, session, requestQueue, sortBy, state) => {
+    const { startUrls, useFilters, simple } = input;
+    const { userData } = request;
+    const { filtered } = userData;
+
+    await waitForStartPageToLoad(page);
+
+    const enqueuingReady = filtered || !(useFilters);
+
+    // Check if the page was opened through working proxy.
+    validateProxy(page, session, startUrls, sortBy);
+
+    // If it's aprropriate, enqueue all pagination pages
+    if (enqueuingReady) {
+        await enqueuePaginationPages(page, input, requestQueue);
+    }
+
+    const items = await getResultsCount(page);
+    if (items.length === 0) {
+        log.info('Found no result. Skipping...');
+        return;
+    }
+
+    if (enqueuingReady && simple) {
+        // If simple output is enough, extract the data.
+        const data = await extractSimpleData(page, input, state);
+        if (data.length > 0) {
+            await Apify.pushData(data);
+        }
+    } else if (enqueuingReady) {
+        // If not, enqueue the detail pages to be extracted.
+        await enqueueDetailPages(page, input, requestQueue);
+    }
+
+    // If filtering is enabled, enqueue necessary pages.
+    if (useFilters) {
+        await enqueueFilterPages(page, request, requestQueue, state);
+    }
+};
+
+const enqueuePaginationPages = async (page, input, requestQueue) => {
+    const { maxPages, useFilters, minMaxPrice, propertyType } = input;
+    if (!maxPages || maxPages > 1 || useFilters || minMaxPrice !== 'none' || propertyType !== 'none') {
+        if (input.useFilters) {
+            await enqueueAllPages(page, requestQueue, input, 0);
+        } else if (!maxPages || maxPages > 1) {
+            await enqueueAllPages(page, requestQueue, input, maxPages);
+        }
+    }
+};
+
+const enqueueDetailPages = async (page, input, requestQueue) => {
+    log.info('enqueuing detail pages...');
+    const urlMod = fixUrl('&', input);
+    const keyMod = async (link) => (await getAttribute(link, 'textContent')).trim().replace(/\n/g, '');
+
+    const prItem = await page.$('.bui-pagination__info');
+    const pageRange = (await getAttribute(prItem, 'textContent')).match(/\d+/g);
+    const firstItem = parseInt(pageRange && pageRange[0] ? pageRange[0] : '1', 10);
+
+    // eslint-disable-next-line max-len
+    const links = await page.$$('.sr_property_block.sr_item:not(.soldout_property) .hotel_name_link, [data-capla-component*="PropertiesListDesktop"] [data-testid="property-card"] a[data-testid="title-link"]');
+
+    for (let iLink = 0; iLink < links.length; iLink++) {
+        const link = links[iLink];
+        const href = await getAttribute(link, 'href');
+
+        if (href) {
+            const uniqueKeyCal = keyMod ? (await keyMod(link)) : href;
+            const urlModCal = urlMod ? urlMod(href) : href;
+
+            await requestQueue.addRequest({
+                userData: {
+                    label: 'detail',
+                    order: iLink + firstItem,
+                },
+                url: urlModCal,
+                uniqueKey: uniqueKeyCal,
+            }, { forefront: true });
+        }
+    }
+};
+
+const enqueueFilterPages = async (page, request, requestQueue, state) => {
+    log.info('enqueuing filtered pages...');
+
+    const attributeToExtract = 'value';
+    const filterCheckboxSelector = `[type="checkbox"][${attributeToExtract}]:not([checked]):not(.bui-checkbox__input)`;
+
+    const extractionInfo = { page, selector: filterCheckboxSelector, attribute: attributeToExtract };
+    const urlInfo = { baseUrl: request.url, label: 'start' };
+
+    await enqueueLinks(extractionInfo, urlInfo, requestQueue, state);
+};
+
+const waitForStartPageToLoad = async (page) => {
+    const countSelector = '.sorth1, .sr_header h1, .sr_header h2, [data-capla-component*="HeaderDesktop"] h1';
+    await page.waitForSelector(countSelector, { timeout: 60000 });
+    const heading = await page.$(countSelector);
+
+    const headingText = heading ? (await getAttribute(heading, 'textContent')).trim() : 'No heading found.';
+    log.info(headingText);
+};
+
+const waitForDetailPageToLoad = async (page) => {
+    try {
+        await page.waitForSelector('.bicon-occupancy');
+    } catch (e) {
+        log.info('occupancy info not found');
+    }
+};
+
+const validateProxy = (page, session, startUrls, requiredQueryParam) => {
+    const pageUrl = page.url();
+    if (!startUrls && pageUrl.indexOf(requiredQueryParam) < 0) {
+        session.retire();
+        throw new Error(`Page was not opened correctly`);
+    }
+};
+
+const getResultsCount = async (page) => {
+    // eslint-disable-next-line max-len
+    const items = await page.$$('.sr_property_block.sr_item:not(.soldout_property), [data-capla-component*="PropertiesListDesktop"] [data-testid="property-card"]');
+
+    return items.length;
+};
+
+const extractSimpleData = async (page, input, state) => {
+    log.info('extracting data...');
+    await Apify.utils.puppeteer.injectJQuery(page);
+    const result = await page.evaluate(listPageFunction, input);
+
+    const toBeAdded = [];
+
+    if (result.length > 0) {
+        for (const item of result) {
+            item.url = addUrlParameters(item.url, input);
+            if (!state.crawled[item.name]) {
+                toBeAdded.push(item);
+                state.crawled[item.name] = true;
+            }
+        }
+
+        log.info(`Found ${toBeAdded.length} new results out of ${result.length} results.`);
+    }
+
+    return toBeAdded;
 };

--- a/src/handle-page-function.js
+++ b/src/handle-page-function.js
@@ -62,9 +62,8 @@ module.exports = async ({ page, request, session, crawler, requestQueue, startUr
         // Handle hotel list page.
         const filtered = await isFiltered(page);
         const settingFilters = input.useFilters && !filtered;
-        const settingMinMaxPrice = input.minMaxPrice !== 'none' && !await isMinMaxPriceSet(page, input);
         const settingPropertyType = input.propertyType !== 'none' && !await isPropertyTypeSet(page, input);
-        const enqueuingReady = !(settingFilters || settingMinMaxPrice || settingPropertyType);
+        const enqueuingReady = !(settingFilters || settingPropertyType);
 
         // Check if the page was open through working proxy.
         const pageUrl = page.url();
@@ -85,11 +84,6 @@ module.exports = async ({ page, request, session, crawler, requestQueue, startUr
         // If property type is enabled, enqueue necessary page.
         if (settingPropertyType) {
             await setPropertyType(page, input, requestQueue);
-        }
-
-        // If min-max price is enabled, enqueue necessary page.
-        if (settingMinMaxPrice && !settingPropertyType) {
-            await setMinMaxPrice(page, input, requestQueue, crawler);
         }
 
         // If filtering is enabled, enqueue necessary pages.

--- a/src/input.js
+++ b/src/input.js
@@ -23,11 +23,11 @@ module.exports.validateInput = (input) => {
             throw new Error('WRONG INPUT: This actor cannot be used without Apify proxy or custom proxies.');
         }
     }
-    if (input.useFilters && input.propertyType !== 'none') {
+    if (input.useFilters && input.propertyType && input.propertyType !== 'none') {
         throw new Error('WRONG INPUT: Property type and filters cannot be used at the same time.');
     }
 
-    if (input.useFilters && input.minMaxPrice !== 'none') {
+    if (input.useFilters && input.minMaxPrice && input.minMaxPrice !== 'none') {
         throw new Error('WRONG INPUT: Price range and filters cannot be used at the same time.');
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ Apify.main(async () => {
     const errorSnapshotter = new ErrorSnapshotter();
     await errorSnapshotter.initialize(Apify.events);
 
-    const state = await Apify.getValue('STATE') || { crawled: {} };
+    const state = await Apify.getValue('STATE') || { crawled: {}, enqueuedUrls: [] };
 
     Apify.events.on('persistState', async () => {
         await Apify.setValue('STATE', state);

--- a/src/main.js
+++ b/src/main.js
@@ -34,9 +34,8 @@ Apify.main(async () => {
     const { requestSources } = await prepareRequestSources({ startUrls, input, maxPages, sortBy });
     const requestList = await Apify.openRequestList('LIST', requestSources);
     const proxyConfiguration = (await Apify.createProxyConfiguration(proxyConfig)) || undefined;
-    const globalContext = {
-        requestQueue, startUrls, input, extendOutputFunction, sortBy, maxPages, state,
-    };
+
+    const globalContext = { requestQueue, input, extendOutputFunction, sortBy, state };
 
     const crawler = new Apify.PuppeteerCrawler({
         requestList,

--- a/src/util.js
+++ b/src/util.js
@@ -289,7 +289,10 @@ module.exports.enqueueAllPages = async (page, requestQueue, input, maxPages) => 
     }
 };
 
-module.exports.enqueueLinks = async (page, selector, attribute, label, baseUrl, requestQueue) => {
+module.exports.enqueueLinks = async (extractionInfo, urlInfo, requestQueue, state) => {
+    const { page, selector, attribute } = extractionInfo;
+    const { label, baseUrl } = urlInfo;
+
     const linkElements = await page.$$(selector);
 
     for (const element of linkElements) {

--- a/src/util.js
+++ b/src/util.js
@@ -155,7 +155,6 @@ const addUrlParametersForHotelListingUrl = (url, input) => {
         { isSet: adults, name: 'group_adults', value: adults },
         { isSet: children, name: 'group_children', value: children },
         { isSet: rooms, name: 'no_rooms', value: rooms },
-        { isSet: true, name: 'review_score', value: minScore ? parseFloat(minScore) * 10 : DEFAULT_MIN_SCORE },
     ];
 
     addMinMaxPriceParameter(minMaxPrice, queryParameters);
@@ -167,6 +166,13 @@ const addUrlParametersForHotelListingUrl = (url, input) => {
             extendedUrl.searchParams.set(name, value);
         }
     });
+
+    if (!url.includes('review_score')) {
+        /* we need to check for url.includes instead of searchParams.has because if startUrl is specified,
+        it might use nflt=review_score query param which can not be checked by searchParams.has effectively due to URI encoding */
+        const reviewScore = minScore ? parseFloat(minScore) * 10 : DEFAULT_MIN_SCORE;
+        extendedUrl.searchParams.set('review_score', reviewScore);
+    }
 
     return extendedUrl.toString();
 };


### PR DESCRIPTION
Resolves #44, resolves #34 

## Circumvent results
`useFilters` option is currently implemented using the following logic (assuming `useFilters === true`):
- New start pages are enqueued in `handleListPage` function, pagination pages are enqueued only if total number of results per current start url is <= 1000. Otherwise filtered pages are enqueued for results count > 1000.
- New filters are detected from unchecked checkboxes, they are mapped to the current url as new query parameters.
- In each enqueuing phase triggered in `handleListPage` function, unchecked filters are iterated and each filter is interpreted as query parameter name. If the filter has multiple value choices, all values are iterated and new url is enqueued for each value.
- Before a new filtered page is enqueued, it is checked against duplicate addition. All urls enqueued using filters are stored in `state` object and newly built url is checked against all stored urls. If an url with exactly same query parameter names is detected, the new url is not enqueued. Query parameter values don't have to match precisely in this url comparsion as all values of a given parameter are processed during 1 filter enqueuing phase.

## Room info
Extraction of rooms info from detail page was added for unset `checkIn` and `checkOut` input attributes. Booking.com doesn't show room features directly inside rooms table without `checkIn`, `checkOut` set so it cannot be scraped effectively (I tried to expand room info using `page.Click('.room-info [href]')` combined with `page.waitForSelector('.hprt-facilities-facility')` (and a few other options) but the overhead was too big and a lot of timeouts were triggered. I added room info url to the output so it can be inspected if needed.)

Example room info:
```json
{
      "url": "https://www.booking.com/hotel/us/zaza-dallas.cs.html?aid=304142;label=gen173nr-1FCAso7AFCC3phemEtZGFsbGFzSDNYBGhniAEBmAEFuAEYyAEM2AEB6AEB-AEGiAIBqAIEuAKYq_eNBsACAdICJGEyOWQzZmMwLTdmOTAtNDcxMS1iMTFiLTQyN2I0YjIxNjZiYdgCBeACAQ;sid=e3e5ca388d08ffa3d72b88094262cc35;dist=0&group_adults=2&group_children=0&hapos=22&hpos=22&keep_landing=1&nflt=review_score%3D84%3Bprice%3DUSD-150-200-1&no_rooms=1&req_adults=2&req_children=0&sb_price_type=total&sr_order=popularity&srepoch=1639830929&srpvid=da7758884dba0107&type=total&ucfs=1&#room_103228202",
      "roomType": "Deluxe Parlor Double",
      "bedType": "2 manželské postele",
      "persons": 2
}
```

## Output schema
Output properties were updated for unset `checkIn` and `checkOut` input attributes. `price`, `currency` and `persons` properties were excluded as `null`  was stored for each of them and resulting dataset was unnecessary bigger because of that.